### PR TITLE
Added Rally Chain

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,7 +92,8 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
-    tokenTypes: [{ id: 20, label: 'Standard Rally Coins'}]
+    tokenTypes: [{ id: 20, label: 'Standard Rally Coins'}],
+    subcoins: 'https://api.rally.io/v1/creator_coins'
   },
 ];
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,6 +92,7 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
+    tokenTypes: [{ id: 20, label: 'Standard Rally Coins'}]
   },
 ];
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,7 +92,7 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
-    tokenTypes: [{ id: 2, label: 'Rally Creator Coins', tokenid: false }],
+    tokenTypes: [{ id: 20, label: 'Rally Creator Coins', tokenid: false }],
     subcoins: 'https://api.rally.io/v1/creator_coins',
   },
 ];

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -79,6 +79,20 @@ const manualChains = [
     infoURL: 'https://www.waves.tech',
     tokenTypes: [{ id: 1, label: 'MintGate NFTs', tokenid: false, nft: true }],
   },
+  {
+    name: 'Rally',
+    isBeta: true,
+    chainId: -90,
+    shortName: 'Rally',
+    chain: 'Rally',
+    network: '',
+    networkId: -90,
+    nativeCurrency: { name: 'RALLY', symbol: 'RLLY', decimals: 18 },
+    rpc: [''],
+    faucets: [],
+    explorers: [],
+    infoURL: 'https://www.rally.io',
+  },
 ];
 
 export const chains: IChainData[] = [

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,7 +92,7 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
-    tokenTypes: [{ id: 20, label: 'Standard Rally coins', tokenid: false }],
+    tokenTypes: [{ id: 20, label: 'Rally Creator Coins', tokenid: false }],
     subcoins: 'https://api.rally.io/v1/creator_coins',
   },
 ];

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,8 +92,8 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
-    tokenTypes: [{ id: 20, label: 'Standard Rally Coins'}],
-    subcoins: 'https://api.rally.io/v1/creator_coins'
+    tokenTypes: [{ id: 20, label: 'Standard Rally coins', tokenid: false }],
+    subcoins: 'https://api.rally.io/v1/creator_coins',
   },
 ];
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -92,7 +92,7 @@ const manualChains = [
     faucets: [],
     explorers: [],
     infoURL: 'https://www.rally.io',
-    tokenTypes: [{ id: 20, label: 'Rally Creator Coins', tokenid: false }],
+    tokenTypes: [{ id: 2, label: 'Rally Creator Coins', tokenid: false }],
     subcoins: 'https://api.rally.io/v1/creator_coins',
   },
 ];


### PR DESCRIPTION
In `src/chains.ts`, under manual chains, I added the Rally chain.

Note to consider:
- Since the Rally chain is not EVM compatible, I used a random negative number (-90) for network ID.
- Our ideal goal is when someone selects the Rally chain on the frontend, it would hide the Token Type selection and then just show a dropdown of all of the Rally tokens available (using the Rally API). However, Rally does intend to introduce the Rally NFTs API and we probably will support Rally NFTs, I did add a token type. 
  }

```
{
    name: 'Rally',
    isBeta: true,
    chainId: -90,
    shortName: 'Rally',
    chain: 'Rally',
    network: '',
    networkId: -90,
    nativeCurrency: { name: 'RALLY', symbol: 'RLLY', decimals: 18 },
    rpc: [''],
    faucets: [],
    explorers: [],
    infoURL: 'https://www.rally.io',
    tokenTypes: [{ id: 20, label: 'Standard Rally Coins'}]
  },
```